### PR TITLE
Scope banner background-transparency to notes with an actual banner

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -33,7 +33,7 @@
 
 
 
-.workspace-split.mod-root .view-content.has-banner {
+.workspace-split.mod-root .view-content.has-banner:has(.banner-image:not(:empty)) {
   background-color: transparent;
 }
 


### PR DESCRIPTION
## Summary
Fixes #84.

`styles.css` makes the core `.view-content` background `transparent` whenever the `has-banner` class is present, so a banner image can show through. But the banner routine adds `has-banner` to a note's view **unconditionally** (before checking whether a `banner` property exists), so notes *without* a banner also pick up the transparent rule — e.g. when coloring a property/tag, or on the active leaf after "Reload app without saving".

On themes that don't re-assert the note background (Baseline, Cupertino) with the **translucent window** enabled, the note content then renders transparent and the desktop (or grey, on focus loss) shows through; closing and reopening the note restores it. This matches the reports in #84.

## Change
One line — scope the transparency to when a real banner image is present, using the `:has(.banner-image:not(:empty))` idiom already used elsewhere in this file:

```diff
-.workspace-split.mod-root .view-content.has-banner {
+.workspace-split.mod-root .view-content.has-banner:has(.banner-image:not(:empty)) {
   background-color: transparent;
 }
```

- Full-bleed banners: unaffected (a banner note has a non-empty `.banner-image`).
- Bannerless notes (incl. coloring properties, and the reload-stale active leaf): keep the theme's normal background → no more bleed-through.

## Testing
Repro on Baseline 3.2.9 + Obsidian (translucent window, macOS): before, coloring a tag or "Reload app without saving" dropped the note background until reopening; after, the background holds in both cases and banners still display.