### PR TITLE
Filter property suggestions by folder

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,6 +128,16 @@ If you Ctrl+click on any property value, the plugin will open search for this va
 
 ![base](images/image_search.png)
 
+### Autocomplete filters
+
+By default Obsidian suggests every value a property has ever had anywhere in the vault. This setting lets you narrow that down per property.
+
+Add a rule in the "Autocomplete filters" tab, pick a property and a folder, and choose whether that folder should be included (only suggest notes from it) or excluded (suggest everything else). Subfolders can be counted or ignored per rule.
+
+For example, a rule for the `areas` property pointing at the `Areas` folder in "include" mode means typing in `areas:` only ever suggests your area notes, instead of every note in the vault.
+
+Rules match on the note a suggestion points to, so they apply to link values. Several rules can target the same property: "include" rules widen the allowed set, while "exclude" rules are always subtracted.
+
 ## Bases support 
 
 Most of the properties functional, including colored properties, custom date formats and math rendering also work in bases.

--- a/src/localization/locales/en.ts
+++ b/src/localization/locales/en.ts
@@ -191,4 +191,13 @@ export default {
   HIDDEN_PROPERTIES: "Hidden properties",
   COVER_SHAPE_PROPERTY: "Cover shape property",
   COVER_POSITION_PROPERTY: "Cover position property",
-};
+  SUGGESTION_FILTERS: "Autocomplete filters",
+  SUGGESTION_FILTERS_DESC: "Restrict which notes a property offers in its autocomplete. Rules match on folder, so they apply to suggestions that resolve to a note; suggestions that are not links are hidden by include rules.",
+  ENABLE_SUGGESTION_FILTERS: "Enable autocomplete filters",
+  ADD_SUGGESTION_FILTER: "Add autocomplete filter",
+  SUGGESTION_FILTER_FOLDER_RULE: "Folder — folder, include/exclude, and whether subfolders count",
+  SUGGESTION_FILTER_FOLDER_PLACEHOLDER: "Folder path",
+  SUGGESTION_FILTER_INCLUDE: "Include",
+  SUGGESTION_FILTER_EXCLUDE: "Exclude",
+  SUGGESTION_FILTER_SUBFOLDERS: "Include subfolders",
+}

--- a/src/localization/locales/ru.ts
+++ b/src/localization/locales/ru.ts
@@ -202,4 +202,13 @@ export default {
   PROPERTY_FORMATTINGS: "Форматы свойств",
   COVER_SHAPE_PROPERTY: "Свойство для формы обложки",
   COVER_POSITION_PROPERTY: "Свойство для положения обложки",
-};
+  SUGGESTION_FILTERS: "Фильтры автодополнения",
+  SUGGESTION_FILTERS_DESC: "Ограничьте, какие заметки предлагаются в автодополнении свойства. Правила работают по папкам.",
+  ENABLE_SUGGESTION_FILTERS: "Включить фильтры автодополнения",
+  ADD_SUGGESTION_FILTER: "Добавить фильтр",
+  SUGGESTION_FILTER_FOLDER_RULE: "Папка — папка, включение/исключение и учёт подпапок",
+  SUGGESTION_FILTER_FOLDER_PLACEHOLDER: "Путь к папке",
+  SUGGESTION_FILTER_INCLUDE: "Включить",
+  SUGGESTION_FILTER_EXCLUDE: "Исключить",
+  SUGGESTION_FILTER_SUBFOLDERS: "Включая подпапки",
+}

--- a/src/patches/patchMetadataSuggester.ts
+++ b/src/patches/patchMetadataSuggester.ts
@@ -2,6 +2,7 @@ import PrettyPropertiesPlugin from "src/main"
 import { around, dedupe } from "monkey-around";
 import { PopoverSuggest } from "obsidian";
 import { setPillStyles } from "src/updates/updatePills";
+import { filterSuggestionValues, getRulesForProperty } from "src/utils/suggestionFilter";
 
 
 
@@ -25,6 +26,27 @@ export const patchMetadataSuggester = (plugin: PrettyPropertiesPlugin) => {
         let textInputEl = this.textInputEl
 
         if (textInputEl instanceof HTMLElement) {
+
+            let propertyEl = textInputEl.closest(".metadata-property")
+            let propertyKey = propertyEl?.getAttribute("data-property-key")
+
+            if (propertyKey && getRulesForProperty(plugin, propertyKey).length) {
+                let values = this.suggestions?.values
+
+                if (Array.isArray(values) && typeof this.suggestions?.setSuggestions == "function") {
+                    let filtered = filterSuggestionValues(plugin, propertyKey, values)
+
+                    if (filtered.length != values.length) {
+                        this.suggestions.setSuggestions(filtered)
+
+                        // Nothing survived the filter, so there is no popover worth opening.
+                        if (!filtered.length) return
+
+                        elements = this.suggestions.suggestions
+                    }
+                }
+            }
+
             let metadataEl = textInputEl.closest(".metadata-property-value")
             if (metadataEl instanceof HTMLElement) {
                 let type = metadataEl.getAttribute("data-property-type")

--- a/src/settings/settings.ts
+++ b/src/settings/settings.ts
@@ -10,6 +10,7 @@ import { showOtherSettings } from './otherSettings';
 import { showColorSettings } from './colorSettings';
 import { showHiddenSettingsTab } from './hiddenSettingsTab';
 import { showFormatSettingsTab } from './formatSettings';
+import { showSuggestionFilterSettings } from './suggestionFilterSettings';
 
 
 
@@ -19,6 +20,16 @@ export interface PillColorSettings {
 	pillColor?: HSL | string | undefined,
 	textColor?: HSL | string | undefined
 }
+export type SuggestionFilterMatch = "folder"
+
+export interface SuggestionFilterRule {
+	property: string,
+	match: SuggestionFilterMatch,
+	value: string,
+	mode: "include" | "exclude",
+	includeSubfolders: boolean
+}
+
 export interface PPPluginSettings {
     hiddenProperties: string[];
     propertyPillColors: Record<string, PillColorSettings>;
@@ -116,6 +127,8 @@ export interface PPPluginSettings {
 	hideCoverCollapsed: boolean,
 	hidePropTitle: boolean,
 	hideAddPropertyButton: boolean,
+	enableSuggestionFilters: boolean,
+	suggestionFilters: SuggestionFilterRule[],
 }
 
 
@@ -227,6 +240,8 @@ export const DEFAULT_SETTINGS: PPPluginSettings = {
 	hideCoverCollapsed: false,
 	hidePropTitle: false,
 	hideAddPropertyButton: false,
+	enableSuggestionFilters: true,
+	suggestionFilters: [],
 
 }
 
@@ -243,7 +258,7 @@ export class PPSettingTab extends PluginSettingTab {
 		const {containerEl} = this;
 		containerEl.empty();
 
-		let tabNames = ["BANNERS", "ICONS", "COVERS", "COLORED_PROPERTIES", "HIDDEN_PROPERTIES", "PROPERTY_FORMATTINGS", "OTHER"]
+		let tabNames = ["BANNERS", "ICONS", "COVERS", "COLORED_PROPERTIES", "HIDDEN_PROPERTIES", "PROPERTY_FORMATTINGS", "SUGGESTION_FILTERS", "OTHER"]
 		let tabsEl = containerEl.createDiv({cls: "pp-settings-tabs"})
 		for (let tabName of tabNames) {
 			let button = tabsEl.createEl("button", {cls: "pp-settings-tab"})
@@ -290,6 +305,11 @@ export class PPSettingTab extends PluginSettingTab {
 
 		
 
+
+
+		else if (this.plugin.settings.settingsTab == "SUGGESTION_FILTERS") {
+			showSuggestionFilterSettings(this)
+		}
 
 
 		else if (this.plugin.settings.settingsTab == "DATES") {

--- a/src/settings/suggestionFilterSettings.ts
+++ b/src/settings/suggestionFilterSettings.ts
@@ -1,0 +1,137 @@
+import { Setting } from 'obsidian';
+import { i18n } from 'src/localization/localization';
+import { PPSettingTab } from 'src/settings/settings';
+import { PropertyNameSuggest } from '../utils/propertyNameSuggester';
+import { FolderSuggest } from '../utils/folderSuggester';
+
+
+
+
+export const showSuggestionFilterSettings = (settingTab: PPSettingTab) => {
+	const { containerEl, plugin } = settingTab
+
+	new Setting(containerEl)
+		.setHeading()
+		.setName(i18n.t("SUGGESTION_FILTERS"))
+		.setDesc(i18n.t("SUGGESTION_FILTERS_DESC"))
+
+	new Setting(containerEl)
+		.setName(i18n.t("ENABLE_SUGGESTION_FILTERS"))
+		.addToggle(toggle => toggle
+			.setValue(plugin.settings.enableSuggestionFilters)
+			.onChange(async (value) => {
+				plugin.settings.enableSuggestionFilters = value
+				await plugin.saveSettings()
+				settingTab.display()
+			}))
+
+	if (!plugin.settings.enableSuggestionFilters) return
+
+	let rulesWrapper = containerEl.createDiv()
+
+	rulesWrapper.setCssProps({
+		border: "1px solid var(--text-accent)",
+		"border-radius": "4px"
+	})
+
+	let rulesEl = rulesWrapper.createDiv()
+
+	for (let i = 0; i < plugin.settings.suggestionFilters.length; i++) {
+		const rule = plugin.settings.suggestionFilters[i]
+		if (!rule) continue
+
+		new Setting(rulesEl)
+			.setName(rule.property)
+			.setDesc(i18n.t("SUGGESTION_FILTER_FOLDER_RULE"))
+
+			.addSearch((search) => {
+				search.setPlaceholder(i18n.t("SUGGESTION_FILTER_FOLDER_PLACEHOLDER"))
+				search.setValue(rule.value)
+
+				const persist = async (value: string) => {
+					rule.value = value
+					await plugin.saveSettings()
+				}
+
+				search.onChange(async (value) => {
+					await persist(value)
+				})
+
+				const suggester = new FolderSuggest(plugin.app, search.inputEl)
+				suggester.onSelect(async (value) => {
+					await persist(value)
+					suggester.setValue(value)
+					suggester.close()
+				})
+			})
+
+			.addDropdown(drop => drop
+				.addOptions({
+					"include": i18n.t("SUGGESTION_FILTER_INCLUDE"),
+					"exclude": i18n.t("SUGGESTION_FILTER_EXCLUDE")
+				})
+				.setValue(rule.mode)
+				.onChange(async (value) => {
+					rule.mode = value == "exclude" ? "exclude" : "include"
+					await plugin.saveSettings()
+				}))
+
+			.addToggle(toggle => toggle
+				.setTooltip(i18n.t("SUGGESTION_FILTER_SUBFOLDERS"))
+				.setValue(rule.includeSubfolders)
+				.onChange(async (value) => {
+					rule.includeSubfolders = value
+					await plugin.saveSettings()
+				}))
+
+			.addButton(btn => btn
+				.setIcon("x")
+				.onClick(async () => {
+					plugin.settings.suggestionFilters.splice(i, 1)
+					await plugin.saveSettings()
+					settingTab.display()
+				}))
+	}
+
+	let newProperty = ""
+
+	new Setting(rulesWrapper)
+		.setName(i18n.t("ADD_SUGGESTION_FILTER"))
+		.addSearch((search) => {
+			search.setValue("")
+			search.setPlaceholder(i18n.t("PROPERTY_SEARCH_PLACEHOLDER"))
+
+			const persist = async (value: string) => {
+				newProperty = value
+			}
+
+			search.onChange(async (value) => {
+				await persist(value)
+			})
+
+			const suggester = new PropertyNameSuggest(plugin.app, search.inputEl)
+			suggester.onSelect(async (value) => {
+				await persist(value)
+				suggester.setValue(value)
+				suggester.close()
+			})
+		})
+
+		.addButton(btn => btn
+			.setIcon("plus")
+			.onClick(async () => {
+				newProperty = newProperty.trim()
+				if (!newProperty) return
+
+				plugin.settings.suggestionFilters.push({
+					property: newProperty,
+					match: "folder",
+					value: "",
+					mode: "include",
+					includeSubfolders: true
+				})
+
+				await plugin.saveSettings()
+				settingTab.display()
+			}))
+}

--- a/src/updates/updateStyles.ts
+++ b/src/updates/updateStyles.ts
@@ -210,7 +210,7 @@ export const updateRelativeDateColors = (plugin: PrettyPropertiesPlugin) => {
 
   }
   document.body.setCssProps(relativeDatesProps);
-  document.body.classList.add(coloredDatesClass)
+  document.body.classList.toggle("colored-dates", coloredDatesClass != "")
 }
 
 

--- a/src/utils/folderSuggester.ts
+++ b/src/utils/folderSuggester.ts
@@ -1,0 +1,25 @@
+import { AbstractInputSuggest, App, TFolder } from "obsidian";
+
+export class FolderSuggest extends AbstractInputSuggest<string> {
+
+	protected getSuggestions(query: string): string[] {
+		const querySanitized = query.trim().toLowerCase();
+		const folders: string[] = [];
+
+		for (let file of this.app.vault.getAllLoadedFiles()) {
+			if (file instanceof TFolder && file.path != "/") {
+				folders.push(file.path);
+			}
+		}
+
+		if (!querySanitized) return folders.sort((a, b) => a.localeCompare(b));
+
+		return folders
+			.filter((f) => f.toLowerCase().includes(querySanitized))
+			.sort((a, b) => a.localeCompare(b));
+	}
+
+	renderSuggestion(value: string, el: HTMLElement): void {
+		el.setText(value);
+	}
+}

--- a/src/utils/suggestionFilter.ts
+++ b/src/utils/suggestionFilter.ts
@@ -1,0 +1,109 @@
+import { TFile } from "obsidian";
+import PrettyPropertiesPlugin from "src/main";
+import { SuggestionFilterRule } from "src/settings/settings";
+
+
+
+
+const normalizeFolder = (folder: string) => folder.replace(/^\/+|\/+$/g, "").trim()
+
+
+
+
+// Suggestion values come in several shapes depending on which suggester is open:
+// plain strings for multitext values, file objects for link suggestions.
+const getRawValue = (value: unknown): string | undefined => {
+	if (typeof value == "string") return value
+	if (!value || typeof value != "object") return undefined
+
+	let obj = value as Record<string, any>
+
+	if (obj.file instanceof TFile) return obj.file.path
+	if (typeof obj.file?.path == "string") return obj.file.path
+	if (typeof obj.path == "string") return obj.path
+	if (typeof obj.value == "string") return obj.value
+	if (typeof obj.alias == "string") return obj.alias
+
+	return undefined
+}
+
+
+
+
+// Turns a suggestion into a vault path, so "[[Health]]", "Areas/Health.md" and
+// "Areas/Health#Goals|Health" all end up as the same note.
+const resolvePath = (plugin: PrettyPropertiesPlugin, raw: string): string | undefined => {
+	let text = raw.trim()
+
+	let wikiMatch = text.match(/^!?\[\[([^\]]+)\]\]$/)
+	if (wikiMatch?.[1]) text = wikiMatch[1]
+
+	let mdMatch = text.match(/^!?\[[^\]]*\]\(([^)]+)\)$/)
+	if (mdMatch?.[1]) text = decodeURIComponent(mdMatch[1])
+
+	text = (text.split("|")[0] ?? "").split("#")[0] ?? ""
+	text = text.trim()
+
+	if (!text) return undefined
+
+	let file = plugin.app.metadataCache.getFirstLinkpathDest(text, "")
+	return file?.path
+}
+
+
+
+
+const matchesRule = (path: string, rule: SuggestionFilterRule) => {
+	let folder = normalizeFolder(rule.value)
+	if (!folder) return false
+
+	if (rule.includeSubfolders) {
+		return path.startsWith(folder + "/")
+	}
+
+	let lastSlash = path.lastIndexOf("/")
+	let parent = lastSlash == -1 ? "" : path.slice(0, lastSlash)
+	return parent == folder
+}
+
+
+
+
+export const getRulesForProperty = (plugin: PrettyPropertiesPlugin, propertyKey: string) => {
+	if (!plugin.settings.enableSuggestionFilters) return []
+
+	let key = propertyKey.trim().toLowerCase()
+
+	return (plugin.settings.suggestionFilters || []).filter(rule =>
+		rule.property.trim().toLowerCase() == key && normalizeFolder(rule.value)
+	)
+}
+
+
+
+
+export const filterSuggestionValues = (
+	plugin: PrettyPropertiesPlugin,
+	propertyKey: string,
+	values: unknown[]
+) => {
+	let rules = getRulesForProperty(plugin, propertyKey)
+	if (!rules.length) return values
+
+	let includes = rules.filter(rule => rule.mode != "exclude")
+	let excludes = rules.filter(rule => rule.mode == "exclude")
+
+	return values.filter(value => {
+		let raw = getRawValue(value)
+		let path = raw ? resolvePath(plugin, raw) : undefined
+
+		// A suggestion that resolves to no note can't be placed in a folder, so
+		// include rules drop it and exclude rules leave it alone.
+		if (!path) return !includes.length
+
+		if (excludes.some(rule => matchesRule(path, rule))) return false
+		if (includes.length && !includes.some(rule => matchesRule(path, rule))) return false
+
+		return true
+	})
+}


### PR DESCRIPTION
Adds a settings tab for restricting which notes a property offers in its autocomplete.

## Why

Obsidian suggests every value a property has ever had anywhere in the vault. For a property whose values all live in one place — an `areas` property pointing at notes in `Areas/`, say — the suggestion list is mostly noise, and there's currently no way to narrow it.

Somewhat related to #58, though that asks for per-folder property *visibility* rather than suggestion filtering. This doesn't implement #58.

## What it looks like

A new "Autocomplete filters" tab holding a list of rules. Each rule is a property, a folder, an include/exclude mode, and whether subfolders count:

```
areas    [Areas    ]  [Include ▾]  [✓ subfolders]  [×]
topics   [Archive  ]  [Exclude ▾]  [  subfolders]  [×]
```

The first rule means typing in `areas:` only suggests notes under `Areas/`.

Multiple rules on one property: include rules OR together (so two include rules widen the allowed set rather than cancelling out), exclude rules are always subtracted.

## How it works

`patchMetadataSuggester` already wraps `PopoverSuggest.prototype.open` to style suggestions. The filter hooks into the same patch: it reads the property key off the enclosing `.metadata-property`, filters `this.suggestions.values`, and calls `setSuggestions()` **before** the existing pill-styling loop runs — so the DOM, the values array, and keyboard navigation stay in sync rather than just hiding elements. If nothing survives the filter, the popover doesn't open at all.

Suggestions are resolved to a path via `metadataCache.getFirstLinkpathDest`, so `[[Health]]`, `Areas/Health.md` and `Areas/Health#Goals|Health` all resolve to the same note. A suggestion that resolves to no note can't be placed in a folder, so include rules drop it and exclude rules leave it alone.

The rule model stores `match: "folder"` as a field rather than assuming folders throughout, so tag or regex matching could be added later without a data migration. I left the match-type dropdown out of the UI for now since a select with one option reads as broken.

Defaults are inert — filtering is enabled but the rule list is empty, so nothing changes until a rule is added.

## Unrelated fix included

`updateRelativeDateColors` calls `document.body.classList.add(coloredDatesClass)`, where `coloredDatesClass` is only assigned when a date color is one of the eight named colors or a raw HSL object. With all three `dateColors` left at `"default"` it stays `""`, and `classList.add("")` throws a `SyntaxError`. Since the function is called unconditionally from `onload`, that aborts the entire plugin load:

```
Plugin failure: pretty-properties SyntaxError: Failed to execute 'add' on 'DOMTokenList': The token provided must not be empty.
```

This hit me on a vault with default date colors and is independent of the `enableRelativeDateColors` toggle. Switched to `classList.toggle("colored-dates", ...)`, which also fixes the class never being removed when date colors are cleared.

Happy to split this into its own PR if you'd prefer to land it separately.

## Notes

- New strings added to both `en.ts` and `ru.ts` — the i18n fallback returns the raw key rather than English, so a missing Russian key would render as `SUGGESTION_FILTERS`. My Russian is machine-assisted, so please correct it.
- `this.suggestions.values` / `setSuggestions()` aren't in the public typings, same as the existing patch in that file.
- README section added under Features.
- Happy to rework the settings shape, drop the exclude mode, or fold this into an existing tab if you'd rather not add another one.
